### PR TITLE
Replace _debug calls with debug for consistency

### DIFF
--- a/adm/daemons/advance.c
+++ b/adm/daemons/advance.c
@@ -62,10 +62,10 @@ int advance(object tp) {
 }
 
 int earn_xp(object tp, int amount) {
-  _debug("earn_xp: " + amount);
-  _debug("xp: " + tp->query_xp());
+  debug("earn_xp: " + amount);
+  debug("xp: " + tp->query_xp());
   tp->adjust_xp(amount);
-  _debug("xp: " + tp->query_xp());
+  debug("xp: " + tp->query_xp());
 
 
   if(mud_config("PLAYER_AUTOLEVEL"))

--- a/adm/daemons/channel.c
+++ b/adm/daemons/channel.c
@@ -53,14 +53,14 @@ void setup() {
     if(ob = find_object(arr[i]))
       ob->remove();
 
-    _debug("> Loading channel module: %s", arr[i]);
+    debug("> Loading channel module: %s", arr[i]);
     time = time_frac();
     err = catch(load_object(arr[i]));
 
     if(err != 0)
-      _debug("< Error %s when loading %s", err, arr[i]);
+      debug("< Error %s when loading %s", err, arr[i]);
     else
-      _debug("< Done (%.2fs)", time_frac() - time);
+      debug("< Done (%.2fs)", time_frac() - time);
   }
 
   set_no_clean(1);
@@ -75,17 +75,17 @@ int register_module(string name, string path) {
 
   if(member_array(name, keys) != -1) {
     if(modules[name] == path)  {
-      _debug("  > Module %s already registered to path %s", name, path);
+      debug("  > Module %s already registered to path %s", name, path);
       return 1;
     } else {
-      _debug("  > Module %s already registered to path %s", name, modules[name]);
+      debug("  > Module %s already registered to path %s", name, modules[name]);
       return -1;
     }
   }
 
   modules[name] = path;
 
-  _debug("  > Module %s registered to path %s", name, path);
+  debug("  > Module %s registered to path %s", name, path);
 
   return 1;
 }
@@ -133,7 +133,7 @@ int register_channel(string module_name, string channel_name) {
 
   channels[new_name] = (["module" : module_name, "real_name" : channel_name, "listeners" : ({})]);
 
-  _debug("   > Channel %s registered to module %s", new_name, module_name);
+  debug("   > Channel %s registered to module %s", new_name, module_name);
 
   return 1;
 }
@@ -318,7 +318,7 @@ void rec_msg(string channel, string user, string msg) {
     "text" : msg,
   ]);
 
-  _debug("PAYLOAD: %O", payload);
+  debug("PAYLOAD: %O", payload);
 
   listeners = channels[channel]["listeners"];
   listeners -= ({ 0 });

--- a/adm/daemons/gmcp.c
+++ b/adm/daemons/gmcp.c
@@ -143,7 +143,7 @@ class ClassGMCP convert_message(string message) {
       gmcp.payload = json_decode(message_info);
     };
     if(err)
-      _debug("Error decoding JSON: %O", chop(err, "\n", -1));
+      debug("Error decoding JSON: %O", chop(err, "\n", -1));
   }
 
   return gmcp;

--- a/adm/daemons/modules/gmcp/Comm.c
+++ b/adm/daemons/modules/gmcp/Comm.c
@@ -24,7 +24,7 @@ inherit STD_DAEMON;
 varargs void Channel(object who, string sub, mapping data) {
   switch(sub) {
     case "Text":
-      _debug("Text", data);
+      debug("Text", data);
       assert((: mapp($(data)) && !nullp($(data)["channel"]) && !nullp($(data)["text"]) :));
 
       if(nullp(data["talker"]))

--- a/adm/simul_efun/system.c
+++ b/adm/simul_efun/system.c
@@ -157,10 +157,16 @@ string doc_dir() {
 /**
  * Logs a debug message, optionally formatted with arguments.
  *
+ * If the first argument is not a string, it will be printed using %O
+ * notation using sprintf.
+ *
+ * If the first argument is a string, it will be printed according to
+ * sprintf, using any following additional arguments as substitutions.
+ *
  * @param {string} str - The debug message.
  * @param {...mixed} [args] - Optional arguments to format the message.
  */
-varargs void _debug(mixed str, mixed args...) {
+varargs void debug(mixed str, mixed args...) {
   if(stringp(str)) {
     if(sizeof(args))
       str = sprintf(str, args...);
@@ -284,7 +290,7 @@ varargs int _ok(mixed args...) {
   if(tp)
     tell(tp, append(result.message, "\n"));
   else
-    _debug(mess);
+    debug(mess);
 
   return 1;
 }
@@ -333,7 +339,7 @@ varargs int _error(mixed args...) {
   if(tp)
     tell(tp, mess + "\n");
   else
-    _debug(mess);
+    debug(mess);
 
   return 1;
 }
@@ -379,7 +385,7 @@ varargs int _warn(mixed args...) {
     if(tp)
         tell(tp, mess + "\n");
     else
-        _debug(mess);
+        debug(mess);
 
     return 1;
 }
@@ -425,7 +431,7 @@ varargs int _info(mixed args...) {
     if(tp)
         tell(tp, mess + "\n");
     else
-        _debug(mess);
+        debug(mess);
 
     return 1;
 }

--- a/d/cavern/cavern_base.c
+++ b/d/cavern/cavern_base.c
@@ -25,5 +25,5 @@ void virtual_setup(mixed args...) {
   __DIR__ "cavern_daemon"->setup_exits(this_object(), file);
   __DIR__ "cavern_daemon"->setup_short(this_object(), file);
   __DIR__ "cavern_daemon"->setup_long(this_object(), file);
-  // _debug("Room type for %O is %O", this_object(), query_room_environment());
+  // debug("Room type for %O is %O", this_object(), query_room_environment());
 }

--- a/d/ellenia/ellenia_base.c
+++ b/d/ellenia/ellenia_base.c
@@ -27,13 +27,13 @@ void virtual_setup(mixed args...) {
   object ob;
 
   set_zone("ellenia");
-  // _debug("Setting up room type for %O", this_object());
+  // debug("Setting up room type for %O", this_object());
   __DIR__ "ellenia_daemon"->setup_room_type(this_object());
   __DIR__ "ellenia_daemon"->setup_room_subtype(this_object());
   __DIR__ "ellenia_daemon"->setup_exits(this_object(), file);
   __DIR__ "ellenia_daemon"->setup_short(this_object(), file);
   __DIR__ "ellenia_daemon"->setup_long(this_object(), file);
-  // _debug("Room type for %O is %O", this_object(), query_room_environment());
+  // debug("Room type for %O is %O", this_object(), query_room_environment());
 
   add_reset((: repopulate :));
 

--- a/d/ellenia/ellenia_daemon.c
+++ b/d/ellenia/ellenia_daemon.c
@@ -178,7 +178,7 @@ public void setup_exits(object room) {
   z = coords[0];
 
   current_room_type = determine_room_type(z, y, x);
-  _debug("Current room type: %s", current_room_type);
+  debug("Current room type: %s", current_room_type);
   if(current_room_type == "impassable")
     return;
 
@@ -230,7 +230,7 @@ private varargs string determine_room_type(int z, int y, int x) {
     to_float(y) / 15.0
   ) + 1.0;
 
-  _debug("Noise value for x%d,y%d,z%d: %f", x, y, z, value);
+  debug("Noise value for x%d,y%d,z%d: %f", x, y, z, value);
 
   if(nullp(value))
     return null;

--- a/d/maze/maze_base.c
+++ b/d/maze/maze_base.c
@@ -20,11 +20,11 @@ void virtual_setup(mixed args...) {
   string file = args[0];
 
   set_zone("twisty_maze");
-  // _debug("Setting up room type for %O", this_object());
+  // debug("Setting up room type for %O", this_object());
   __DIR__ "maze_daemon"->setup_room_type(this_object());
   __DIR__ "maze_daemon"->setup_room_subtype(this_object());
   __DIR__ "maze_daemon"->setup_exits(this_object(), file);
   __DIR__ "maze_daemon"->setup_short(this_object(), file);
   __DIR__ "maze_daemon"->setup_long(this_object(), file);
-  // _debug("Room type for %O is %O", this_object(), query_room_environment());
+  // debug("Room type for %O is %O", this_object(), query_room_environment());
 }

--- a/d/wastes/wastes_base.c
+++ b/d/wastes/wastes_base.c
@@ -27,13 +27,13 @@ void virtual_setup(mixed args...) {
   object ob;
 
   set_zone("barren_wasteland");
-  // _debug("Setting up room type for %O", this_object());
+  // debug("Setting up room type for %O", this_object());
   __DIR__ "wastes_daemon"->setup_room_type(this_object());
   __DIR__ "wastes_daemon"->setup_room_subtype(this_object());
   __DIR__ "wastes_daemon"->setup_exits(this_object(), file);
   __DIR__ "wastes_daemon"->setup_short(this_object(), file);
   __DIR__ "wastes_daemon"->setup_long(this_object(), file);
-  // _debug("Room type for %O is %O", this_object(), query_room_environment());
+  // debug("Room type for %O is %O", this_object(), query_room_environment());
 
   add_reset((: repopulate :));
 

--- a/std/modules/clean.c
+++ b/std/modules/clean.c
@@ -35,13 +35,13 @@ void set_debug_clean(int i) {
   object *contents;
   int check;
 
-  if(debug_clean) _debug("%O checking if we are to clean up.", this_object());
+  if(debug_clean) debug("%O checking if we are to clean up.", this_object());
 
   // If we have an environment, straight up don't ask again. We can never
   // lose our environment and only non-environmented things are cleaned up.
   // Things with an environment rely on their environment to clean them up.
   if(environment()) {
-    if(debug_clean) _debug("   ❌ %O never cleaning again because it has an environment.", this_object());
+    if(debug_clean) debug("   ❌ %O never cleaning again because it has an environment.", this_object());
     return CLEAN_NEVER_AGAIN;
   }
 
@@ -52,14 +52,14 @@ void set_debug_clean(int i) {
   check = clean_up_check(this_object());
 
   if(check > 0) {
-    if(debug_clean) _debug("   ❌ %O never cleaning again because it is a user, interactive, or is no_clean.", this_object());
+    if(debug_clean) debug("   ❌ %O never cleaning again because it is a user, interactive, or is no_clean.", this_object());
     return CLEAN_NEVER_AGAIN;
   }
 
   // Now ask permission to clean up. If we answer false, we'll check again
   // later.
   if(request_clean_up() == 0) {
-    if(debug_clean) _debug("   ⌛ %O cleaning up later because it requested not to clean up.", this_object());
+    if(debug_clean) debug("   ⌛ %O cleaning up later because it requested not to clean up.", this_object());
     return CLEAN_LATER;
   }
 
@@ -68,9 +68,9 @@ void set_debug_clean(int i) {
   // virtual items, because refs is weird with them.
   // if(clonep())
   if(refs > 1) {
-    if(debug_clean) _debug("   ⌛ Number of references: %O", refs);
+    if(debug_clean) debug("   ⌛ Number of references: %O", refs);
     if(!virtualp()) {
-      if(debug_clean) _debug("   ⌛ %O cleaning up later because it has more than one reference.", this_object());
+      if(debug_clean) debug("   ⌛ %O cleaning up later because it has more than one reference.", this_object());
       return CLEAN_LATER;
     }
   }
@@ -84,7 +84,7 @@ void set_debug_clean(int i) {
     calls = filter(calls, (: $1[0] == $2 :), this_object());
 
     if(sizeof(calls)) {
-      if(debug_clean) _debug("   ⌛ %O cleaning up later because it has pending call_outs.", this_object());
+      if(debug_clean) debug("   ⌛ %O cleaning up later because it has pending call_outs.", this_object());
       return CLEAN_LATER;
     }
   }
@@ -93,13 +93,13 @@ void set_debug_clean(int i) {
   // determine if we have any items in us that need to be cleaned up.
   contents = deep_inventory();
   if(clean_up_check(contents) > 0) {
-    if(debug_clean) _debug("   ⌛ %O cleaning up later because it has users or interactives in it.", this_object());
+    if(debug_clean) debug("   ⌛ %O cleaning up later because it has users or interactives in it.", this_object());
     return CLEAN_LATER;
   }
 
   contents = filter(contents, (: $1->request_clean_up() == 0 :));
   if(sizeof(contents)) {
-    if(debug_clean) _debug("   ⌛ %O cleaning up later because it has items that requested not to clean up.", this_object());
+    if(debug_clean) debug("   ⌛ %O cleaning up later because it has items that requested not to clean up.", this_object());
     return CLEAN_LATER;
   }
 
@@ -112,7 +112,7 @@ void set_debug_clean(int i) {
   contents -= ({ 0 });
   contents->move(ROOM_VOID);
 
-  if(debug_clean) _debug("   ✔️ %O cleaning up now.", this_object());
+  if(debug_clean) debug("   ✔️ %O cleaning up now.", this_object());
 
   call_if(this_object(), "remove");
 

--- a/std/modules/log.c
+++ b/std/modules/log.c
@@ -97,7 +97,7 @@ varargs void _log(mixed args...) {
         prefix = sprintf("[%s] %s", ldatetime(), prefix);
 
     if(sizeof(rest))
-        _debug(prefix + message, rest...);
+        debug(prefix + message, rest...);
     else
-        _debug(prefix + message);
+        debug(prefix + message);
 }

--- a/std/modules/proc.c
+++ b/std/modules/proc.c
@@ -147,16 +147,16 @@ string can_proc() {
   string result;
   float roll;
 
-  _debug("can_proc: Checking for procs.");
+  debug("can_proc: Checking for procs.");
   // If there are no procs, return false
   if(!sizeof(_procs))
     return false;
-  _debug("can_proc: There are %d procs.", sizeof(_procs));
+  debug("can_proc: There are %d procs.", sizeof(_procs));
 
   // If the proc chance is 0, return false
   if(_proc_chance <= 0.0)
     return false;
-  _debug("can_proc: Proc chance is %f.", _proc_chance);
+  debug("can_proc: Proc chance is %f.", _proc_chance);
 
   // Iterate through all procs and check if they can proc, if they have
   // a cooldown
@@ -165,15 +165,15 @@ string can_proc() {
       if(now - _cooldowns[name] > proc["cooldown"])
         procs[name] = proc["chance"] || 100;
   }
-  _debug("can_proc: Procs: %O", procs);
+  debug("can_proc: Procs: %O", procs);
 
   if(!sizeof(procs))
     return false;
-  _debug("can_proc: Final procs: %O", procs);
+  debug("can_proc: Final procs: %O", procs);
   // Now let's check which proc can occur. This is based on the weight of
   // the proc.
   result = element_of_weighted(procs);
-  _debug("can_proc: Result: %s", result);
+  debug("can_proc: Result: %s", result);
   return result;
 }
 
@@ -186,9 +186,9 @@ varargs void proc(string name, mixed args...) {
   mapping proc = query_proc(name);
   mixed func;
 
-  _debug("proc: Calling proc %s.", name);
+  debug("proc: Calling proc %s.", name);
   if(nullp(proc)) {
-    _debug("proc: Proc %s not found.", name);
+    debug("proc: Proc %s not found.", name);
     return;
   }
 


### PR DESCRIPTION
Standardize the logging function by replacing all instances of `_debug` with `debug` across various files. This change enhances code consistency and readability.